### PR TITLE
Fixed some parsing and rendering issues

### DIFF
--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,5 +1,3 @@
 <component name="CopyrightManager">
-  <settings default="">
-    <module2copyright />
-  </settings>
+  <settings default="" />
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,6 +4,11 @@
     <asm skipDebug="false" skipFrames="false" skipCode="false" expandFrames="false" />
     <groovy codeStyle="LEGACY" />
   </component>
+  <component name="EclipseCodeFormatter">
+    <option name="defaultSettings" value="true" />
+    <option name="id" value="1417888591523" />
+    <option name="name" value="default" />
+  </component>
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
@@ -73,4 +78,3 @@
   </component>
   <component name="WebServicesPlugin" addRequiredLibraries="true" />
 </project>
-

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="hg4idea" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>
-

--- a/build/build.dependencies
+++ b/build/build.dependencies
@@ -4,7 +4,7 @@ mvn:junit:junit-dep:jar|sources:4.8.2
 
 mvn:antlr:antlr:jar:2.7.7
 mvn:org.antlr:stringtemplate:jar:3.2.1
-mvn:com.thoughtworks.qdox:qdox:jar:1.12
+mvn:com.thoughtworks.qdox:qdox:jar:1.12.1
 http://jarjar.googlecode.com/files/jarjar-1.1.jar
 
 mvn://repo.bodar.com/com.googlecode.totallylazy:totallylazy:pack|sources:1130

--- a/src/com/googlecode/yatspec/parsing/Files.java
+++ b/src/com/googlecode/yatspec/parsing/Files.java
@@ -17,12 +17,20 @@ public class Files {
         System.out.println("Yatspec output:\n" + output);
     }
 
+    public static String toJavaResourcePath(Class testClass) {
+        return toResourcePath(testClass) + ".java";
+    }
+
     public static String toJavaPath(Class testClass) {
         return toPath(testClass) + ".java";
     }
 
     public static String toHtmlPath(Class testClass) {
         return toPath(testClass) + ".html";
+    }
+
+    public static String toResourcePath(Class clazz) {
+        return replaceDotsWithForwardSlashes(clazz.getName());
     }
 
     public static String toPath(Class clazz) {
@@ -33,10 +41,22 @@ public class Files {
         return characters(name).map(dotsToSlashes()).toString(Strings.EMPTY, Strings.EMPTY, Strings.EMPTY);
     }
 
+    public static String replaceDotsWithForwardSlashes(final String name) {
+        return characters(name).map(dotsToForwardSlashes()).toString(Strings.EMPTY, Strings.EMPTY, Strings.EMPTY);
+    }
+
     private static Callable1<? super Character, Character> dotsToSlashes() {
         return new Callable1<Character, Character>() {
             public Character call(Character character) throws Exception {
                 return character == '.' ? File.separatorChar : character;
+            }
+        };
+    }
+
+    private static Callable1<? super Character, Character> dotsToForwardSlashes() {
+        return new Callable1<Character, Character>() {
+            public Character call(Character character) throws Exception {
+                return character == '.' ? '/' : character;
             }
         };
     }

--- a/src/com/googlecode/yatspec/parsing/TestParser.java
+++ b/src/com/googlecode/yatspec/parsing/TestParser.java
@@ -32,6 +32,7 @@ import static com.googlecode.totallylazy.Sequences.sequence;
 import static com.googlecode.totallylazy.Strings.endsWith;
 import static com.googlecode.totallylazy.URLs.toURL;
 import static com.googlecode.yatspec.parsing.Files.toJavaPath;
+import static com.googlecode.yatspec.parsing.Files.toJavaResourcePath;
 
 public class TestParser {
 
@@ -111,7 +112,7 @@ public class TestParser {
     }
 
     private static Option<URL> getJavaSourceFromClassPath(Class aClass) {
-        return isObject(aClass) ? NO_URL : option(aClass.getClassLoader().getResource(toJavaPath(aClass)));
+        return isObject(aClass) ? NO_URL : option(aClass.getClassLoader().getResource(toJavaResourcePath(aClass)));
     }
 
     private static Option<URL> getJavaSourceFromFileSystem(Class aClass) {

--- a/src/com/googlecode/yatspec/parsing/wordDelimiter.regex
+++ b/src/com/googlecode/yatspec/parsing/wordDelimiter.regex
@@ -3,7 +3,7 @@
 (?:                         # start a non capturing group so that we can do an 'or'
 (?<!^)([A-Z][a-z])
 |                           # or
-([^a-zA-Z_0-9\r\n\.])       # not a word character, end of line or full stop
+([^a-zA-Z_\-0-9\r\n\.])       # not a word character, end of line or full stop
 |                           # or
 ((?=[^\d]+)\.(?=[^\d]+))    # a period not surrounded by digits
 )                           # end non-capturing group

--- a/src/com/googlecode/yatspec/rendering/html/JavaSourceRenderer.java
+++ b/src/com/googlecode/yatspec/rendering/html/JavaSourceRenderer.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 import static com.googlecode.totallylazy.Sequences.sequence;
 import static com.googlecode.totallylazy.Xml.escape;
 import static com.googlecode.yatspec.parsing.Text.wordify;
+import static java.lang.System.lineSeparator;
 
 public class JavaSourceRenderer implements Renderer<JavaSource> {
     private static final Pattern DOT_CLASS = Pattern.compile("\\.class(\\W|$)");
@@ -19,11 +20,7 @@ public class JavaSourceRenderer implements Renderer<JavaSource> {
     }
 
     public static Sequence<String> lines(final String sourceCode) {
-        return sequence(sourceCode.split(lineSeperator()));
-    }
-
-    public static String lineSeperator() {
-        return System.getProperty("line.separator");
+        return sequence(sourceCode.split(lineSeparator()));
     }
 
     public static String removateDotClass(String s) {

--- a/src/com/googlecode/yatspec/rendering/wiki/JavaSourceRenderer.java
+++ b/src/com/googlecode/yatspec/rendering/wiki/JavaSourceRenderer.java
@@ -3,15 +3,14 @@ package com.googlecode.yatspec.rendering.wiki;
 import com.googlecode.totallylazy.Callable1;
 import com.googlecode.totallylazy.Predicate;
 import com.googlecode.totallylazy.Sequence;
-import com.googlecode.totallylazy.Strings;
 import com.googlecode.totallylazy.regex.Regex;
 import com.googlecode.yatspec.parsing.JavaSource;
 import com.googlecode.yatspec.rendering.Renderer;
 
 import static com.googlecode.totallylazy.Predicates.not;
-import static com.googlecode.totallylazy.Sequences.sequence;
 import static com.googlecode.totallylazy.Strings.EMPTY;
 import static com.googlecode.yatspec.rendering.html.JavaSourceRenderer.lines;
+import static java.lang.System.lineSeparator;
 
 public class JavaSourceRenderer implements Renderer<JavaSource> {
     @Override
@@ -28,7 +27,7 @@ public class JavaSourceRenderer implements Renderer<JavaSource> {
         String indentation = lines.
                 find(not(blankLine())).
                 map(indentation()).getOrElse("");
-        return lines.map(remove(indentation)).toString("\n");
+        return lines.map(remove(indentation)).toString(lineSeparator());
     }
 
     private Callable1<String, String> remove(final String indentation) {

--- a/src/com/googlecode/yatspec/state/TestMethod.java
+++ b/src/com/googlecode/yatspec/state/TestMethod.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import static com.googlecode.totallylazy.Sequences.sequence;
 import static com.googlecode.yatspec.junit.YatspecAnnotation.methods.yatspecAnnotations;
+import static java.lang.System.lineSeparator;
 
 @SuppressWarnings({"unused"})
 public class TestMethod {
@@ -93,7 +94,7 @@ public class TestMethod {
 
     @Override
     public String toString() {
-        return getName() + System.getProperty("line.separator") + getSpecification();
+        return getName() + lineSeparator() + getSpecification();
     }
 
     public ScenarioTable getScenarioTable() {

--- a/test/com/googlecode/yatspec/parsing/TestParserTest.java
+++ b/test/com/googlecode/yatspec/parsing/TestParserTest.java
@@ -49,14 +49,14 @@ public class TestParserTest {
     public void supportsQuotationMarksInParameters(String value) throws Exception {
         assertThat(value, is("string with\" quotes"));
     }
-//    This breaks the parsing
-//    @Test
-//    @Table({
-//            @Row({"string with\\ escape chars"})
-//    })
-//    public void supportsEscapedCharactersInParameters(String value) throws Exception {
-//        assertThat(value, is("string with\\ escape chars"));
-//    }
+
+    @Test
+    @Table({
+            @Row({"string with\\ escape chars"})
+    })
+    public void supportsEscapedCharactersInParameters(String value) throws Exception {
+        assertThat(value, is("string with\\ escape chars"));
+    }
 
     @Test
     public void shouldParseTestMethodsFromClassFoundInClassPathRatherThanFileSystem() throws Exception {

--- a/test/com/googlecode/yatspec/parsing/TextTest.java
+++ b/test/com/googlecode/yatspec/parsing/TextTest.java
@@ -1,11 +1,9 @@
 package com.googlecode.yatspec.parsing;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 
 public class TextTest {
     @Test
@@ -29,5 +27,12 @@ public class TextTest {
         assertThat(Text.wordify("assertThat(sqrt(421.0704), is(20.520));"), is("Assert that sqrt 421.0704 is 20.520"));
         assertThat(Text.wordify("13.37 66.6 3.33"), is("13.37 66.6 3.33"));
         assertThat(Text.wordify("someMethod(12.5,99, 22.22"), is("Some method 12.5 99 22.22"));
+    }
+
+    @Test
+    public void doesNotRemoveMinusSignForNumbers() throws Exception {
+        assertThat(Text.wordify("-13.37"), is("-13.37"));
+        assertThat(Text.wordify("-0"), is("-0"));
+        assertThat(Text.wordify("-1"), is("-1"));
     }
 }

--- a/test/com/googlecode/yatspec/rendering/html/HtmlResultRendererTest.java
+++ b/test/com/googlecode/yatspec/rendering/html/HtmlResultRendererTest.java
@@ -8,7 +8,7 @@ import com.googlecode.yatspec.state.TestResult;
 import com.googlecode.yatspec.state.givenwhenthen.TestState;
 import org.junit.Test;
 
-import java.io.File;
+import java.nio.file.Paths;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,7 +24,7 @@ public class HtmlResultRendererTest {
     public void providesLinksToResultOutputRelativeToOutputDirectory() throws Exception {
         assertThat(
                 HtmlResultRenderer.htmlResultRelativePath(this.getClass()),
-                is("com/googlecode/yatspec/rendering/html/HtmlResultRendererTest.html"));
+                is(Paths.get("com/googlecode/yatspec/rendering/html/HtmlResultRendererTest.html").toString()));
     }
 
     @Test

--- a/test/com/googlecode/yatspec/rendering/wiki/JavaSourceRendererTest.java
+++ b/test/com/googlecode/yatspec/rendering/wiki/JavaSourceRendererTest.java
@@ -3,13 +3,16 @@ package com.googlecode.yatspec.rendering.wiki;
 import com.googlecode.yatspec.parsing.JavaSource;
 import org.junit.Test;
 
+import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class JavaSourceRendererTest {
     @Test
     public void removesFirstLevelOfIndentation() throws Exception {
-        assertThat(new JavaSourceRenderer().render(new JavaSource("\tFoo\n\tBar")), is("Foo\nBar"));
+        String withIndentation = "\tFoo" + lineSeparator() +"\tBar";
+        String withoutIndentation = "Foo" + lineSeparator() + "Bar";
+        assertThat(new JavaSourceRenderer().render(new JavaSource(withIndentation)), is(withoutIndentation));
     }
 
     @Test


### PR DESCRIPTION
Updated QDox to 1.12.1 to fix a bug where escaped characters cannot be parsed (see TestParserTest.supportsEscapedCharactersInParameters). Also fixed portability issues with line separators in tests. Note that ClassLoader.getResource expects a '/'-separated path name always.

Consider - to be a part of words so negative numbers do not have the negative sign chopped off.