### PR TITLE
add LinkingNote annotation

### DIFF
--- a/src/com/googlecode/yatspec/junit/LinkingNote.java
+++ b/src/com/googlecode/yatspec/junit/LinkingNote.java
@@ -1,0 +1,15 @@
+package com.googlecode.yatspec.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@YatspecAnnotation
+public @interface LinkingNote {
+    String message();
+    Class[] links();
+
+}

--- a/src/com/googlecode/yatspec/rendering/LinkingNoteRenderer.java
+++ b/src/com/googlecode/yatspec/rendering/LinkingNoteRenderer.java
@@ -1,0 +1,28 @@
+package com.googlecode.yatspec.rendering;
+
+import com.googlecode.totallylazy.Callable1;
+import com.googlecode.totallylazy.Sequence;
+import com.googlecode.yatspec.junit.LinkingNote;
+
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.yatspec.junit.SpecRunner.outputDirectory;
+import static com.googlecode.yatspec.parsing.Text.wordify;
+import static com.googlecode.yatspec.rendering.html.HtmlResultRenderer.htmlResultFile;
+import static java.lang.String.format;
+
+public class LinkingNoteRenderer implements Renderer<LinkingNote>{
+
+    @Override
+    public String render(LinkingNote linkingNoteNotes) throws Exception {
+        return format(linkingNoteNotes.message(), (Object[])sequence(linkingNoteNotes.links()).map(link()).toArray(String.class));
+    }
+
+    private Callable1<Class, String> link() {
+        return new Callable1<Class, String>() {
+            @Override
+            public String call(Class aClass) throws Exception {
+                return format("<a href='%s'>%s</a>", htmlResultFile(outputDirectory(), aClass), wordify(aClass.getSimpleName()));
+            }
+        };
+    }
+}

--- a/src/com/googlecode/yatspec/rendering/html/HtmlResultRenderer.java
+++ b/src/com/googlecode/yatspec/rendering/html/HtmlResultRenderer.java
@@ -6,14 +6,12 @@ import com.googlecode.totallylazy.Pair;
 import com.googlecode.totallylazy.Predicate;
 import com.googlecode.totallylazy.Xml;
 import com.googlecode.yatspec.Creator;
+import com.googlecode.yatspec.junit.LinkingNote;
 import com.googlecode.yatspec.junit.Notes;
 import com.googlecode.yatspec.junit.SpecResultListener;
 import com.googlecode.yatspec.parsing.Files;
 import com.googlecode.yatspec.parsing.JavaSource;
-import com.googlecode.yatspec.rendering.Content;
-import com.googlecode.yatspec.rendering.NotesRenderer;
-import com.googlecode.yatspec.rendering.Renderer;
-import com.googlecode.yatspec.rendering.ScenarioTableHeaderRenderer;
+import com.googlecode.yatspec.rendering.*;
 import com.googlecode.yatspec.state.Result;
 import com.googlecode.yatspec.state.ScenarioTableHeader;
 import com.googlecode.yatspec.state.Status;
@@ -54,6 +52,7 @@ public class HtmlResultRenderer implements SpecResultListener {
         group.registerRenderer(instanceOf(ScenarioTableHeader.class), callable(new ScenarioTableHeaderRenderer()));
         group.registerRenderer(instanceOf(JavaSource.class), callable(new JavaSourceRenderer()));
         group.registerRenderer(instanceOf(Notes.class), callable(new NotesRenderer()));
+        group.registerRenderer(instanceOf(LinkingNote.class), callable(new LinkingNoteRenderer()));
         group.registerRenderer(instanceOf(Content.class), asString());
         sequence(customRenderers).fold(group, registerRenderer());
         for (Class document : Creator.optionalClass("org.jdom.Document")) {

--- a/test/com/googlecode/yatspec/junit/LinkingNoteRendererTest.java
+++ b/test/com/googlecode/yatspec/junit/LinkingNoteRendererTest.java
@@ -1,0 +1,29 @@
+package com.googlecode.yatspec.junit;
+
+import com.googlecode.yatspec.rendering.LinkingNoteRenderer;
+import com.googlecode.yatspec.state.TestMethod;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.yatspec.junit.SpecRunner.outputDirectory;
+import static com.googlecode.yatspec.parsing.TestParser.parseTestMethods;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(SpecRunner.class)
+public class LinkingNoteRendererTest {
+    @Test
+    @LinkingNote(message="Classes specified in the linking note should result in links to the resulted yatspec output eg. %s, %s", links = {String.class, Integer.class})
+    public void shouldRenderLinkedNotesAsNotesWithLinksToTheYatspecOutputOfTheTestClassesSpecified() throws Exception {
+        assertThat(theRenderedValueOfTheLinkingNoteOfThisMethod(),
+                is("Classes specified in the linking note should result in links to the resulted yatspec output eg. <a href='" + outputDirectory() +"/java/lang/String.html'>String</a>, <a href='" + outputDirectory() + "/java/lang/Integer.html'>Integer</a>"));
+    }
+
+    private String theRenderedValueOfTheLinkingNoteOfThisMethod() throws Exception {
+        final List<TestMethod> methods = parseTestMethods(getClass());
+        return new LinkingNoteRenderer().render(sequence(sequence(methods).first().getAnnotations()).safeCast(LinkingNote.class).head());
+    }
+}

--- a/test/com/googlecode/yatspec/junit/SpecificationExampleTest.java
+++ b/test/com/googlecode/yatspec/junit/SpecificationExampleTest.java
@@ -47,6 +47,12 @@ public class SpecificationExampleTest extends TestState implements WithCustomRes
     }
 
     @Test
+    @LinkingNote(message = "The details of how the Linking Note works can be seen in the %s", links = {LinkingNoteRendererTest.class})
+    public void testWithALinkingNote() throws Exception {
+
+    }
+
+    @Test
     public void printEmptyTestName() throws Exception {
 
     }


### PR DESCRIPTION
Hi Dan,

We needed notes from which we can link to the result of other tests. Also we wanted to specify the test name as class so all the refactorings like rename, move will update the links. For these we created a LinkingNote annotation which combine the note as message and the tests you want to link to as a list of classes.

Does it make any sense?

Thanks,
Laszlo and Rob