### PR TITLE
VarargsParameterResolver should only support varargs as the last parameter, not an array

### DIFF
--- a/src/com/googlecode/yatspec/junit/VarargsParameterResolver.java
+++ b/src/com/googlecode/yatspec/junit/VarargsParameterResolver.java
@@ -13,7 +13,7 @@ public class VarargsParameterResolver implements ParameterResolver {
         final Object[] suppliedParams = row.value();
         final Class<?>[] requiredParams = testMethod.getParameterTypes();
 
-        if (requiresNoVarArgs(requiredParams)) {
+        if (!testMethod.isVarArgs()) {
             return suppliedParams;
         }
 
@@ -22,10 +22,6 @@ public class VarargsParameterResolver implements ParameterResolver {
         }
 
         return sequence(suppliedParams).take(Math.min(requiredParams.length - 1, suppliedParams.length)).append(getVarargsFrom(suppliedParams, requiredParams)).toArray();
-    }
-
-    private boolean requiresNoVarArgs(Class<?>[] methodParams) {
-        return !methodParams[methodParams.length - 1].isArray();
     }
 
     private boolean isMissingRequiredArguments(Object[] input, Class<?>[] expected) {

--- a/test/com/googlecode/yatspec/fixture/VarargFixture.java
+++ b/test/com/googlecode/yatspec/fixture/VarargFixture.java
@@ -3,7 +3,15 @@ package com.googlecode.yatspec.fixture;
 import java.util.HashMap;
 import java.util.Map;
 
+@SuppressWarnings("unused")
 public class VarargFixture {
+
+    public Map<String, Object> arrayOnly(String[] lotsOfParams) {
+        Map<String, Object> recordedParams = new HashMap<String, Object>();
+        recordedParams.put("lotsOfParams", lotsOfParams);
+        return recordedParams;
+    }
+
     public Map<String, Object> varargsOnly(String... lotsOfParams) {
         Map<String, Object> recordedParams = new HashMap<String, Object>();
         recordedParams.put("lotsOfParams", lotsOfParams);

--- a/test/com/googlecode/yatspec/junit/DecoratingFrameworkMethodVarargsTest.java
+++ b/test/com/googlecode/yatspec/junit/DecoratingFrameworkMethodVarargsTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static com.googlecode.totallylazy.Sequences.sequence;
 import static com.googlecode.yatspec.junit.DecoratingFrameworkMethodTest.row;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -36,8 +37,13 @@ public class DecoratingFrameworkMethodVarargsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void shouldFailIfLastArgumentIsAnArray() throws Throwable {
+        checkNonVarargs(getMethod("arrayOnly"), singletonList("someParam"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void shouldFailOnMissingParams() throws Throwable {
-        checkNonVarargs(getMethod("someParamsAndVarargs"), asList("someParam"));
+        checkNonVarargs(getMethod("someParamsAndVarargs"), singletonList("someParam"));
     }
 
     private void testFixtureMethodCalled(String methodName) throws Throwable {


### PR DESCRIPTION
The previous behaviour was causing the `VarargsParameterResolver` to resolve the `@Row("example")` for a test method like `public void test(String[] argument)` as:
`new Object[]{new String{"example"}}`

when I need it to resolve as:
`new Object[]{"example"}`

for a `ParameterResolver` plugin for yatspec I am working on that will delegate to `VarargsParameterResolver` to deal with varargs and add some additional functionality on top of that.