### PR TITLE
Fixing page width.

### DIFF
--- a/src/com/googlecode/yatspec/rendering/html/yatspec.css
+++ b/src/com/googlecode/yatspec/rendering/html/yatspec.css
@@ -9,6 +9,7 @@ html, body {
 
 body {
     position: absolute;
+    width: 95%;
 }
 
 h1, h2, h3, h4, h5, h6, th {


### PR DESCRIPTION
Fixing page width to 95% to make the page take up the full width. This is due to the body having being changed to absolute in a previous change. This fix makes the page go back to full width
