### PR TITLE
Fixing some small rendering bugs

### DIFF
--- a/build/build.dependencies
+++ b/build/build.dependencies
@@ -5,7 +5,7 @@ mvn:junit:junit-dep:jar|sources:4.8.2
 mvn:antlr:antlr:jar:2.7.7
 mvn:org.antlr:stringtemplate:jar:3.2.1
 mvn:com.thoughtworks.qdox:qdox:jar:1.12.1
-http://jarjar.googlecode.com/files/jarjar-1.1.jar
+http://central.maven.org/maven2/com/googlecode/jarjar/jarjar/1.1/jarjar-1.1.jar
 
 mvn://repo.bodar.com/com.googlecode.totallylazy:totallylazy:pack|sources:1130
 mvn://repo.bodar.com/com.googlecode.funclate:funclate:pack|sources:110

--- a/build/shavenmaven.xml
+++ b/build/shavenmaven.xml
@@ -7,7 +7,7 @@
 
         <sequential>
             <mkdir dir="@{directory}"/>
-            <get src="http://shavenmaven.googlecode.com/files/shavenmaven-@{version}.jar"
+            <get src="http://repo.bodar.com/com/googlecode/shavenmaven/shavenmaven/@{version}/shavenmaven-@{version}.jar"
                  dest="@{directory}/shavenmaven.jar" usetimestamp="true"/>
         </sequential>
     </macrodef>

--- a/src/com/googlecode/yatspec/plugin/sequencediagram/dialogScriptHeaderContent.html
+++ b/src/com/googlecode/yatspec/plugin/sequencediagram/dialogScriptHeaderContent.html
@@ -1,6 +1,6 @@
-<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css" type="text/css" media="all"/>
+<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css" type="text/css" media="all"/>
 <link rel="stylesheet" href="http://static.jquery.com/ui/css/demo-docs-theme/ui.theme.css" type="text/css" media="all"/>
-<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" type="text/javascript"></script>
 
 <style type="text/css">
     .ui-dialog {

--- a/src/com/googlecode/yatspec/rendering/html/index/index.st
+++ b/src/com/googlecode/yatspec/rendering/html/index/index.st
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <title>Yatspec Index</title>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" type="text/javascript"></script>
     $stylesheet:{
     <style type="text/css">
             /* <![CDATA[ */

--- a/src/com/googlecode/yatspec/rendering/html/tagindex/index.st
+++ b/src/com/googlecode/yatspec/rendering/html/tagindex/index.st
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <title>Yatspec Tag Index</title>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" type="text/javascript"></script>
     $stylesheet:{
     <style type="text/css">
             /* <![CDATA[ */

--- a/src/com/googlecode/yatspec/rendering/html/yatspec.css
+++ b/src/com/googlecode/yatspec/rendering/html/yatspec.css
@@ -9,6 +9,8 @@ html, body {
 
 body {
     position: absolute;
+    left: 0;
+    right: 0;
 }
 
 h1, h2, h3, h4, h5, h6, th {
@@ -217,9 +219,6 @@ dl.index-result {
     margin-right: 5px;
 }
 
-.section div {
-    width:100%;
-}
 .section .section-header {
     padding: 2px;
     cursor: pointer;

--- a/src/com/googlecode/yatspec/rendering/html/yatspec.st
+++ b/src/com/googlecode/yatspec/rendering/html/yatspec.st
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
     <head>
         <title>$testSuite$</title>
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js" type="text/javascript"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" type="text/javascript"></script>
 
         $customHeaderContent:{
         $it$

--- a/test/com/googlecode/yatspec/rendering/HighlightingCheck.html
+++ b/test/com/googlecode/yatspec/rendering/HighlightingCheck.html
@@ -4,7 +4,7 @@
     <title></title>
     <link rel=StyleSheet href="../../../../../src/com/googlecode/yatspec/rendering/html/yatspec.css" type="text/css"/>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" type="text/javascript"></script>
     <script src="../../../../../src/com/googlecode/yatspec/rendering/html/xregexp.js" TYPE="text/javascript" MEDIA=screen></script>
     <script src="../../../../../src/com/googlecode/yatspec/rendering/html/yatspec.js" TYPE="text/javascript" MEDIA=screen></script>
 


### PR DESCRIPTION
As mentioned in #36, one of my earlier commits that set the body `position: absolute;` inadvertently made the content width smaller. I have set `left: 0;` and `right: 0;` on the body now to make the content fit the page width again. I also removed `width: 100%` from `.section div` because it was spilling off the edge of the scenario div.