### PR TITLE
Loading jquery over HTTPS and updating versions. 

### DIFF
--- a/src/com/googlecode/yatspec/plugin/sequencediagram/dialogScriptHeaderContent.html
+++ b/src/com/googlecode/yatspec/plugin/sequencediagram/dialogScriptHeaderContent.html
@@ -1,6 +1,8 @@
-<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css" type="text/css" media="all"/>
-<link rel="stylesheet" href="http://static.jquery.com/ui/css/demo-docs-theme/ui.theme.css" type="text/css" media="all"/>
-<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
+<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css"
+      type="text/css" media="all"/>
+<link rel="stylesheet" href="https://static.jquery.com/ui/css/demo-docs-theme/ui.theme.css" type="text/css"
+      media="all"/>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" type="text/javascript"></script>
 
 <style type="text/css">
     .ui-dialog {

--- a/src/com/googlecode/yatspec/rendering/html/index/index.st
+++ b/src/com/googlecode/yatspec/rendering/html/index/index.st
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <title>Yatspec Index</title>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
     $stylesheet:{
     <style type="text/css">
             /* <![CDATA[ */

--- a/src/com/googlecode/yatspec/rendering/html/tagindex/index.st
+++ b/src/com/googlecode/yatspec/rendering/html/tagindex/index.st
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <title>Yatspec Tag Index</title>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
     $stylesheet:{
     <style type="text/css">
             /* <![CDATA[ */

--- a/src/com/googlecode/yatspec/rendering/html/yatspec.css
+++ b/src/com/googlecode/yatspec/rendering/html/yatspec.css
@@ -7,6 +7,10 @@ html, body {
     font-size: 10pt;
 }
 
+body {
+    position: absolute;
+}
+
 h1, h2, h3, h4, h5, h6, th {
     text-transform: capitalize;
 }

--- a/src/com/googlecode/yatspec/rendering/html/yatspec.st
+++ b/src/com/googlecode/yatspec/rendering/html/yatspec.st
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
     <head>
         <title>$testSuite$</title>
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js" type="text/javascript"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js" type="text/javascript"></script>
 
         $customHeaderContent:{
         $it$

--- a/test/com/googlecode/yatspec/rendering/HighlightingCheck.html
+++ b/test/com/googlecode/yatspec/rendering/HighlightingCheck.html
@@ -4,7 +4,7 @@
     <title></title>
     <link rel=StyleSheet href="../../../../../src/com/googlecode/yatspec/rendering/html/yatspec.css" type="text/css"/>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
     <script src="../../../../../src/com/googlecode/yatspec/rendering/html/xregexp.js" TYPE="text/javascript" MEDIA=screen></script>
     <script src="../../../../../src/com/googlecode/yatspec/rendering/html/yatspec.js" TYPE="text/javascript" MEDIA=screen></script>
 


### PR DESCRIPTION
Hi,

We also needed to add the body position absolute back into the Yatspec CSS as removing this was causing issues when hovering over dialogs. The browser window would jump to the bottom of the screen and no dialog would appear. Adding the CSS back in, resolves this issue.

The HTTPS fix should resolve Issue #35 