### PR TITLE
Setting width to fill the width of the screen due to bug in jQuery UI…

### DIFF
--- a/src/com/googlecode/yatspec/rendering/html/yatspec.css
+++ b/src/com/googlecode/yatspec/rendering/html/yatspec.css
@@ -9,6 +9,7 @@ html, body {
 
 body {
     position: absolute;
+    width: 95%;
 }
 
 h1, h2, h3, h4, h5, h6, th {


### PR DESCRIPTION
Due to a bug in jQuery UI insisting that we set the body position of absolute. This in turn, shrinks the width of the Yatspec output which is causing issues for some teams. 
