### PR TITLE
Words followed by a number should have a space between them

### DIFF
--- a/src/com/googlecode/yatspec/parsing/Text.java
+++ b/src/com/googlecode/yatspec/parsing/Text.java
@@ -11,8 +11,16 @@ import static com.googlecode.totallylazy.regex.Regex.regex;
 
 public class Text {
     private static final Regex wordDelimiter = Regex.regex(Strings.toString(Text.class.getResourceAsStream("wordDelimiter.regex")));
+    private static final Regex wordNumberDelimiter = Regex.regex("([a-z])([0-9])"); // detect boundaries where letters meet numbers
     private static final Pattern spaceRemover = Pattern.compile("(?<!^)[\\t\\x0B\\f ]+"); // don't replace new lines
     private static final Regex quotedStrings = regex("\"[^\"]+\"");
+
+    private static final Callable1<MatchResult, CharSequence> wordNumberDelimiterReplacer = new Callable1<MatchResult, CharSequence>() {
+        public String call(MatchResult matchResult) {
+            // for example "d4" -> "d 4"
+            return matchResult.group(1) + " " + matchResult.group(2);
+        }
+    };
 
     private static final Callable1<MatchResult, CharSequence> wordDelimiterReplacer = new Callable1<MatchResult, CharSequence>() {
         public String call(MatchResult matchResult) {
@@ -27,7 +35,8 @@ public class Text {
 
     private static final Callable1<CharSequence, CharSequence> wordifier = new Callable1<CharSequence, CharSequence>() {
         public CharSequence call(CharSequence text) {
-            return wordDelimiter.findMatches(text).replace(wordDelimiterReplacer);
+            String wordified = wordDelimiter.findMatches(text).replace(wordDelimiterReplacer);
+            return wordNumberDelimiter.findMatches(wordified).replace(wordNumberDelimiterReplacer);
         }
     };
 

--- a/test/com/googlecode/yatspec/parsing/TextTest.java
+++ b/test/com/googlecode/yatspec/parsing/TextTest.java
@@ -6,6 +6,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class TextTest {
+
+    @Test
+    public void numberAfterWordHasASpace() {
+        assertThat(Text.wordify("word404NewWord"), is("Word 404 new word"));
+    }
+
     @Test
     public void insertsASingleSpacesBetweenCapitalsAndTrims() {
          assertThat(Text.wordify("replaceAWithB;"), is("Replace a with b"));


### PR DESCRIPTION
For example `shouldReturn404WithErrorWhenBlah` currently renders as:
`Should return404 with error when blah`

But we want it to render:
`Should return 404 with error when blah`

